### PR TITLE
iOSshoppe - clicking "add to cart" only increments the shopping cart counter once for each product

### DIFF
--- a/swift/ios-shoppe-demo/Resources/Utilities.swift
+++ b/swift/ios-shoppe-demo/Resources/Utilities.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 func getPlist(withName name: String) -> [String: String]? {
-    if  let path = Bundle.main.path(forResource: name, ofType: "plist"),
+    if let path = Bundle.main.path(forResource: name, ofType: "plist"),
         let xml = FileManager.default.contents(atPath: path) {
         return (try? PropertyListSerialization.propertyList(from: xml, options: .mutableContainersAndLeaves, format: nil)) as? [String: String]
     }

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -11,8 +11,28 @@ import UIKit
 class StoreViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
 
     var products: [Product] = []
-    var cartNumberView = UIBarButtonItem()
-    var cartNumber: Int = 0
+
+    // MARK: - NavigationBar Button Properties
+
+    var barCartButton: UIBarButtonItem {
+        let button = UIBarButtonItem(image: UIImage(named: "shopping_cart"), style: .done, target: self, action: #selector(openCart))
+        button.tintColor = .white
+        return button
+    }
+
+    var cartNumberView: UIBarButtonItem = UIBarButtonItem() {
+        didSet {
+            cartNumberView.tintColor = .white
+        }
+    }
+
+    var cartNumber: Int = 0 {
+        didSet {
+            setCartUI()
+        }
+    }
+
+    // MARK: - View Life Cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,28 +62,50 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
 
     override func viewWillAppear(_ animated: Bool) {
         updateCartNumber()
-        setupNavigationBar()
     }
 
+    // MARK: - UI Methods
+
     func setupNavigationBar() {
-        let barCartButton = UIBarButtonItem(image: UIImage(named: "shopping_cart"), style: .done, target: self, action: #selector(openCart))
         let textAttributes = [NSAttributedString.Key.foregroundColor:UIColor.white]
 
         cartNumberView = UIBarButtonItem(title: "\(cartNumber)", style: .done, target: self, action: nil)
-        cartNumberView.tintColor = .white
-        barCartButton.tintColor = .white
 
         navigationController?.navigationBar.titleTextAttributes = textAttributes
         navigationController?.navigationBar.barTintColor = UIColor(displayP3Red: 206/255, green: 78/255, blue: 142/255, alpha: 1.0)
 
         navigationItem.title = "iOS Shoppe"
-        navigationItem.rightBarButtonItems = [cartNumberView, barCartButton]
+
+        setCartUI()
+
         collectionView.register(UINib(nibName: "ProductCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "cell")
+        collectionView.backgroundColor = UIColor().fsBackground()
+    }
+
+    func updateCartNumber() {
+        let numberOfItems = order.items.reduce(0, { $0 + $1.quantity })
+
+        cartNumber = numberOfItems
+    }
+
+    func setCartUI() {
+        cartNumberView = UIBarButtonItem(title: "\(cartNumber)", style: .done, target: self, action: nil)
+        navigationItem.rightBarButtonItems = [cartNumberView, barCartButton]
+    }
+
+    func addToCart(_ product: String) {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
+        order.addProduct(product)
+        updateCartNumber()
     }
 
     @objc func openCart() {
         self.navigationController?.pushViewController(CartTableViewController(), animated: true)
     }
+
+    // MARK: - CollectionViewDelegate Methods
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
@@ -84,25 +126,5 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
 
         return CGSize(width: 375, height: 300)
-    }
-
-    func addToCart(_ product: String) {
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
-
-        order.addProduct(product)
-        updateCartNumber()
-        setupNavigationBar()
-    }
-
-    func updateCartNumber() {
-        let orderItems = order.items.filter({ $0.quantity > 0 })
-        var count: Int = 0
-
-        for item in orderItems {
-            count += item.quantity
-        }
-
-        cartNumber = count
     }
 }

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -11,6 +11,8 @@ import UIKit
 class StoreViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
 
     var products: [Product] = []
+    var cartNumberView = UIBarButtonItem()
+    var cartNumber: Int = 0
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,19 +40,24 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        updateCartNumber()
+        setupNavigationBar()
+    }
+
     func setupNavigationBar() {
         let barCartButton = UIBarButtonItem(image: UIImage(named: "shopping_cart"), style: .done, target: self, action: #selector(openCart))
         let textAttributes = [NSAttributedString.Key.foregroundColor:UIColor.white]
 
+        cartNumberView = UIBarButtonItem(title: "\(cartNumber)", style: .done, target: self, action: nil)
+        cartNumberView.tintColor = .white
         barCartButton.tintColor = .white
 
         navigationController?.navigationBar.titleTextAttributes = textAttributes
         navigationController?.navigationBar.barTintColor = UIColor(displayP3Red: 206/255, green: 78/255, blue: 142/255, alpha: 1.0)
 
         navigationItem.title = "iOS Shoppe"
-        navigationItem.rightBarButtonItem = barCartButton
-
-        collectionView.backgroundColor = UIColor().fsBackground()
+        navigationItem.rightBarButtonItems = [cartNumberView, barCartButton]
         collectionView.register(UINib(nibName: "ProductCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "cell")
     }
 
@@ -70,16 +77,32 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath) as? ProductCollectionViewCell
         cell?.product = products[indexPath.row]
         cell?.collectionView = self
-        
+
         return cell ?? UICollectionViewCell()
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
+
         return CGSize(width: 375, height: 300)
     }
 
     func addToCart(_ product: String) {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
         order.addProduct(product)
+        updateCartNumber()
+        setupNavigationBar()
+    }
+
+    func updateCartNumber() {
+        let orderItems = order.items.filter({ $0.quantity > 0 })
+        var count: Int = 0
+
+        for item in orderItems {
+            count += item.quantity
+        }
+
+        cartNumber = count
     }
 }

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -69,8 +69,6 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
     func setupNavigationBar() {
         let textAttributes = [NSAttributedString.Key.foregroundColor:UIColor.white]
 
-        cartNumberView = UIBarButtonItem(title: "\(cartNumber)", style: .done, target: self, action: nil)
-
         navigationController?.navigationBar.titleTextAttributes = textAttributes
         navigationController?.navigationBar.barTintColor = UIColor(displayP3Red: 206/255, green: 78/255, blue: 142/255, alpha: 1.0)
 


### PR DESCRIPTION
Expected: If I click "Add to cart" for "Bananas" three times, then the shopping cart counter should display "3"

Actual: If I click "Add to cart" for "Bananas" three times, then the shopping cart counter displays "1"