### PR TITLE
Update version of iOS FS Framework 1.4.1

### DIFF
--- a/swift/Podfile
+++ b/swift/Podfile
@@ -6,7 +6,7 @@ target 'ios-shoppe-demo' do
   use_frameworks!
 
   # Pods for ios-shoppe-demo
-pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.1.0.tar.gz'
+pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.4.1.tar.gz'
 
   target 'ios-shoppe-demoTests' do
     inherit! :search_paths

--- a/swift/Podfile.lock
+++ b/swift/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
-  - FullStory (1.1.0)
+  - FullStory (1.4.1)
 
 DEPENDENCIES:
-  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.1.0.tar.gz\"}`)"
+  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.4.1.tar.gz\"}`)"
 
 EXTERNAL SOURCES:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.1.0.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.4.1.tar.gz
 
 CHECKOUT OPTIONS:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.1.0.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.4.1.tar.gz
 
 SPEC CHECKSUMS:
-  FullStory: 931387833d819c00ff185a2ce6480de5ea5413dd
+  FullStory: 7153fd5de9c7f261a993e9a946ec108ad5782783
 
-PODFILE CHECKSUM: 8c2c3a39ad741ce58f451114bb1d22aef8984d6d
+PODFILE CHECKSUM: f6314ca9fe263ade827502cef7b661efe998200d
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
# This PR addresses the following:
- `ios-shoppe` is out of date in regards to the version of the `iOS` version of `FullStory` it is using.