### PR TITLE
Harolddavis/ch120552/demonstrate masking and un masking in ios

### DIFF
--- a/swift/ios-shoppe-demo/Model/ProductViewCell.swift
+++ b/swift/ios-shoppe-demo/Model/ProductViewCell.swift
@@ -26,8 +26,6 @@ class ProductViewCell: UITableViewCell {
     }
 
     func setupMasking() {
-        fsModifyPrivacy(setting: .unmask, views: titleLabel)
-        fsModifyPrivacy(setting: .unmask, views: quantityLabel)
-        fsModifyPrivacy(setting: .unmask, views: totalLabel)
+        fsModifyPrivacy(setting: .unmask, views: titleLabel, quantityLabel, totalLabel)
     }
 }

--- a/swift/ios-shoppe-demo/Model/ProductViewCell.swift
+++ b/swift/ios-shoppe-demo/Model/ProductViewCell.swift
@@ -26,8 +26,8 @@ class ProductViewCell: UITableViewCell {
     }
 
     func setupMasking() {
-        fsModifyPrivacy(setting: .unmask, of: titleLabel)
-        fsModifyPrivacy(setting: .unmask, of: quantityLabel)
-        fsModifyPrivacy(setting: .unmask, of: totalLabel)
+        fsModifyPrivacy(setting: .unmask, views: titleLabel)
+        fsModifyPrivacy(setting: .unmask, views: quantityLabel)
+        fsModifyPrivacy(setting: .unmask, views: totalLabel)
     }
 }

--- a/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
+++ b/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
@@ -35,7 +35,6 @@ enum PrivacySetting: String {
     case unmask = "fs-unmask"
 }
 
-
 func fsCreateEvent(event: Event, with dict: [String: Any]) {
     FS.event(event.rawValue, properties: dict)
 }
@@ -59,14 +58,10 @@ func fsLog(message: String, level: LogLevel = .info) {
     FS.log(with: fsLogType, message: "\(Date())" + message)
 }
 
-func fsModifyPrivacy(setting: PrivacySetting, of view: UIView) {
-    FS.addClass(view, className: setting.rawValue)
-}
-
-func fsModifyPrivacy(setting: PrivacySetting, views: [UIView?]) {
+func fsModifyPrivacy(setting: PrivacySetting, views: UIView?...) {
     views.forEach { view in
         if let view = view {
-            fsModifyPrivacy(setting: setting, of: view)
+            FS.addClass(view, className: setting.rawValue)
         }
     }
 }

--- a/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
+++ b/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
@@ -63,6 +63,14 @@ func fsModifyPrivacy(setting: PrivacySetting, of view: UIView) {
     FS.addClass(view, className: setting.rawValue)
 }
 
+func fsModifyPrivacy(setting: PrivacySetting, views: [UIView?]) {
+    views.forEach { view in
+        if let view = view {
+            fsModifyPrivacy(setting: setting, of: view)
+        }
+    }
+}
+
 func fsIdentify(id: String, userInfo: [String: Any]) {
     FS.identify(id, userVars: userInfo)
 }

--- a/swift/ios-shoppe-demo/Views/ProductCollectionViewCell.swift
+++ b/swift/ios-shoppe-demo/Views/ProductCollectionViewCell.swift
@@ -26,7 +26,7 @@ class ProductCollectionViewCell: UICollectionViewCell {
 
     func setup() {
         // MARK: - FullStory Unmasking Example
-        fsModifyPrivacy(setting: .unmask, of: self)
+        fsModifyPrivacy(setting: .unmask, views: self)
 
         DispatchQueue.main.async {
             self.curveViewCornersWithShadow()

--- a/swift/ios-shoppe-demo/Views/ProductCollectionViewCell.swift
+++ b/swift/ios-shoppe-demo/Views/ProductCollectionViewCell.swift
@@ -25,6 +25,9 @@ class ProductCollectionViewCell: UICollectionViewCell {
     var collectionView: StoreViewController?
 
     func setup() {
+        // MARK: - FullStory Unmasking Example
+        fsModifyPrivacy(setting: .unmask, of: self)
+
         DispatchQueue.main.async {
             self.curveViewCornersWithShadow()
             self.addToCartButton.curveViewCornersWithShadow()

--- a/swift/ios-shoppe-demo/Views/ProductSummaryDetailCell.swift
+++ b/swift/ios-shoppe-demo/Views/ProductSummaryDetailCell.swift
@@ -16,6 +16,7 @@ class ProductSummaryDetailCell: UITableViewCell {
     @IBOutlet weak var shippingAddress: UILabel!
 
     func setupFSMaskingElements() {
-
+        // MARK: - FullStory masking Example
+        fsModifyPrivacy(setting: .mask, views: [nameLabel, shippingAddress])
     }
 }

--- a/swift/ios-shoppe-demo/Views/ProductSummaryDetailCell.swift
+++ b/swift/ios-shoppe-demo/Views/ProductSummaryDetailCell.swift
@@ -17,6 +17,6 @@ class ProductSummaryDetailCell: UITableViewCell {
 
     func setupFSMaskingElements() {
         // MARK: - FullStory masking Example
-        fsModifyPrivacy(setting: .mask, views: [nameLabel, shippingAddress])
+        fsModifyPrivacy(setting: .mask, views: nameLabel, shippingAddress)
     }
 }

--- a/swift/ios-shoppe-demo/Views/ProductSummaryView.swift
+++ b/swift/ios-shoppe-demo/Views/ProductSummaryView.swift
@@ -19,6 +19,9 @@ class ProductSummaryView: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // MARK: - FullStory unmasking Example
+        fsModifyPrivacy(setting: .unmask, of: tableView)
+
         tableView.register(UINib(nibName: "ProductSummaryCell", bundle: nil), forCellReuseIdentifier: "quantity")
         tableView.register(UINib(nibName: "ProductSummaryTopCell", bundle: nil), forCellReuseIdentifier: "thankYou")
         tableView.register(UINib(nibName: "ProductSummaryUserDetailCell", bundle: nil), forCellReuseIdentifier: "userDetails")

--- a/swift/ios-shoppe-demo/Views/ProductSummaryView.swift
+++ b/swift/ios-shoppe-demo/Views/ProductSummaryView.swift
@@ -20,7 +20,7 @@ class ProductSummaryView: UITableViewController {
         super.viewDidLoad()
 
         // MARK: - FullStory unmasking Example
-        fsModifyPrivacy(setting: .unmask, of: tableView)
+        fsModifyPrivacy(setting: .unmask, views: tableView)
 
         tableView.register(UINib(nibName: "ProductSummaryCell", bundle: nil), forCellReuseIdentifier: "quantity")
         tableView.register(UINib(nibName: "ProductSummaryTopCell", bundle: nil), forCellReuseIdentifier: "thankYou")

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -89,8 +89,13 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
     }
 
     func setCartUI() {
+        let rightBarButtonItems = [cartNumberView, barCartButton]
+
+        // MARK: - FullStory unmasking Example
+        fsModifyPrivacy(setting: .unmask, views: rightBarButtonItems.map { $0.customView })
+
         cartNumberView = UIBarButtonItem(title: "\(cartNumber)", style: .done, target: self, action: nil)
-        navigationItem.rightBarButtonItems = [cartNumberView, barCartButton]
+        navigationItem.rightBarButtonItems = rightBarButtonItems
     }
 
     func addToCart(_ product: String) {

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -89,13 +89,11 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
     }
 
     func setCartUI() {
-        let rightBarButtonItems = [cartNumberView, barCartButton]
-
         // MARK: - FullStory unmasking Example
-        fsModifyPrivacy(setting: .unmask, views: rightBarButtonItems.map { $0.customView })
+        fsModifyPrivacy(setting: .unmask, views: cartNumberView.customView, barCartButton.customView)
 
         cartNumberView = UIBarButtonItem(title: "\(cartNumber)", style: .done, target: self, action: nil)
-        navigationItem.rightBarButtonItems = rightBarButtonItems
+        navigationItem.rightBarButtonItems = [cartNumberView, barCartButton]
     }
 
     func addToCart(_ product: String) {


### PR DESCRIPTION
# This PR addresses the following:
- Most elements should be unmasked in this project.
- Items that are personal should stay masked.

## Code Changes:

### ProductSummaryDetailCell.swift
- In `setupFSMaskingElements` FullStory `masking` Example

### ProductSummaryView.swift
- In `viewDidLoad` FullStory `unmasking` Example
- In `setCartUI` FullStory `unmasking` Example
- In `setupNavigationBar` FullStory `unmasking` Example

### ProductCollectionViewCell.swift
- In the `setup` method FullStory `unmasking` Example
