### PR TITLE
Empty cart when when checking out

### DIFF
--- a/swift/ios-shoppe-demo/Views/ProductSummaryView.swift
+++ b/swift/ios-shoppe-demo/Views/ProductSummaryView.swift
@@ -29,6 +29,7 @@ class ProductSummaryView: UITableViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        order.items.forEach { $0.quantity = 0 }
         checkoutTableViewController.navigationController?.popToRootViewController(animated: true)
     }
 


### PR DESCRIPTION
## This PR addresses the following:
- Cart should be empty when a customer as checked out.