### PR TITLE
adding events with properties

### DIFF
--- a/swift/ios-shoppe-demo/Model/Order.swift
+++ b/swift/ios-shoppe-demo/Model/Order.swift
@@ -9,33 +9,31 @@
 import Foundation
 
 class Order {
-    var items: [String: Product] = [:]
+    var items: [Product] = []
     var date: Date = Date()
     var orderId: String = makeId(len: 9)
     var shipping: Double = 5.99
     var tax: Double = 2.85
     var cartOrderTotal: Double {
-        return items.reduce(0, { $0 + getTotal(for: $1.value) })
+        return items.reduce(0, { $0 + getTotal(for: $1) })
     }
 
-    func addItems(items: [Product]){
-        for item in items {
-            self.items[item.title] = item
-        }
-    }
-
-    func addProduct(_ productName: String ) {
-        items[productName]?.quantity += 1
+    func setItems(items: [Product]){
+        self.items.removeAll()
+        items.forEach{ self.items.append($0) }
     }
 
     func getProduct(_ productName: String ) -> Product? {
-        return items[productName]
+        return items.first(where: { $0.title == productName })
+    }
+
+    func addProduct(_ productName: String ) {
+        getProduct(productName)?.quantity += 1;
     }
 
     func getFilteredItems() -> [Product] {
         return items
-            .filter{ $0.value.quantity > 0 }
-            .map{ $0.value }
+            .filter{ $0.quantity > 0 }
     }
 
     func getNumberOfItems() -> Int{
@@ -43,7 +41,7 @@ class Order {
     }
 
     func resetOrder() {
-        self.items.forEach{ $0.value.quantity = 0 }
+        self.items.forEach{ $0.quantity = 0 }
         self.orderId = makeId(len: 9)
     }
 

--- a/swift/ios-shoppe-demo/Model/Order.swift
+++ b/swift/ios-shoppe-demo/Model/Order.swift
@@ -32,8 +32,7 @@ class Order {
     }
 
     func getFilteredItems() -> [Product] {
-        return items
-            .filter{ $0.quantity > 0 }
+        return items.filter{ $0.quantity > 0 }
     }
 
     func getNumberOfItems() -> Int{
@@ -48,13 +47,11 @@ class Order {
     // converting order to dictionary for FS events
     func orderSummary() -> [String: Any] {
         let filteredItems = getFilteredItems()
-        
         var orderDict: [String: Any] = [:]
 
         for item in filteredItems {
             orderDict[item.title] = item.quantity
         }
-        
         orderDict["order_id_str"] = orderId
         orderDict["revenue_real"] = cartOrderTotal
         orderDict["shipping_real"] = shipping

--- a/swift/ios-shoppe-demo/Model/Order.swift
+++ b/swift/ios-shoppe-demo/Model/Order.swift
@@ -9,28 +9,51 @@
 import Foundation
 
 class Order {
-    var items: [Product] = []
+    var items: [String: Product] = [:]
     var date: Date = Date()
     var orderId: String = makeId(len: 9)
     var shipping: Double = 5.99
     var tax: Double = 2.85
     var cartOrderTotal: Double {
-        return items.reduce(0, { $0 + getTotal(for: $1) })
+        return items.reduce(0, { $0 + getTotal(for: $1.value) })
+    }
+
+    func addItems(items: [Product]){
+        for item in items {
+            self.items[item.title] = item
+        }
     }
 
     func addProduct(_ productName: String ) {
-        items.filter { $0.title == productName }.first?.quantity += 1
-    }
-    
-    func getProduct(_ productName: String ) -> Product? {
-        return items.filter { $0.title == productName }.first
+        items[productName]?.quantity += 1
     }
 
+    func getProduct(_ productName: String ) -> Product? {
+        return items[productName]
+    }
+
+    func getFilteredItems() -> [Product] {
+        return items
+            .filter{ $0.value.quantity > 0 }
+            .map{ $0.value }
+    }
+
+    func getNumberOfItems() -> Int{
+        return getFilteredItems().reduce(0, { $0 + $1.quantity })
+    }
+
+    func resetOrder() {
+        self.items.forEach{ $0.value.quantity = 0 }
+        self.orderId = makeId(len: 9)
+    }
+
+    // converting order to dictionary for FS events
     func orderSummary() -> [String: Any] {
-        let sortedItems: [Product] = items.filter { $0.quantity > 0 }
+        let filteredItems = getFilteredItems()
+        
         var orderDict: [String: Any] = [:]
 
-        for item in sortedItems {
+        for item in filteredItems {
             orderDict[item.title] = item.quantity
         }
         

--- a/swift/ios-shoppe-demo/Model/Order.swift
+++ b/swift/ios-shoppe-demo/Model/Order.swift
@@ -11,12 +11,19 @@ import Foundation
 class Order {
     var items: [Product] = []
     var date: Date = Date()
+    var orderId: String = makeId(len: 9)
+    var shipping: Double = 5.99
+    var tax: Double = 2.85
     var cartOrderTotal: Double {
         return items.reduce(0, { $0 + getTotal(for: $1) })
     }
 
     func addProduct(_ productName: String ) {
         items.filter { $0.title == productName }.first?.quantity += 1
+    }
+    
+    func getProduct(_ productName: String ) -> Product? {
+        return items.filter { $0.title == productName }.first
     }
 
     func orderSummary() -> [String: Any] {
@@ -26,6 +33,11 @@ class Order {
         for item in sortedItems {
             orderDict[item.title] = item.quantity
         }
+        
+        orderDict["order_id_str"] = orderId
+        orderDict["revenue_real"] = cartOrderTotal
+        orderDict["shipping_real"] = shipping
+        orderDict["tax_real"] = tax
 
         return orderDict
     }

--- a/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
+++ b/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
@@ -102,15 +102,13 @@ func fsIdentify(id: String, userInfo: [String: Any]) {
 
 // below are functions for demostrating conversions: revenue attribution events
 func makeId(len: Int) -> String {
-    let letters : NSString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    let length = UInt32(letters.length)
+    let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
     var randomString = ""
 
     for _ in 0 ..< len {
-        let rand = arc4random_uniform(length)
-        var nextChar = letters.character(at: Int(rand))
-        randomString += NSString(characters: &nextChar, length: 1) as String
+        let randomCharacter = characters.randomElement()!
+        randomString.append(randomCharacter)
     }
 
     return randomString

--- a/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
+++ b/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
@@ -20,6 +20,7 @@ FullStory Manager provides common functions and artifacts that make it easier to
 
 /// The Event enum represents major events in an iOS app. These may differ based on your particular app.
 enum Event: String {
+    // TODO: add string values for all events
     case addToCart = "Product Added"
     case browsing
     case checkout = "Order Completed"

--- a/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
+++ b/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
@@ -116,8 +116,8 @@ func makeId(len: Int) -> String {
 }
 
 // ------------------------
-// below are functions for demostrating conversions: revenue attribution events
-// ------------------------
+// MARK: - Conversions, revenue attribution events
+
 func fsAddOrRemoveProductEvent(event: Event, with product: Product?) {
     guard let product = product else {
         return

--- a/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
+++ b/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
@@ -99,13 +99,13 @@ func fsIdentify(id: String, userInfo: [String: Any]) {
     FS.identify(id, userVars: userInfo)
 }
 
-
-// below are functions for demostrating conversions: revenue attribution events
+/**
+Generate a unique alphanumeric ID with specified len
+    - Parameter len: Desired length of ID string
+*/
 func makeId(len: Int) -> String {
     let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
     var randomString = ""
-
     for _ in 0 ..< len {
         let randomCharacter = characters.randomElement()!
         randomString.append(randomCharacter)
@@ -114,11 +114,14 @@ func makeId(len: Int) -> String {
     return randomString
 }
 
-func fsCreateEvent(event: Event, with product: Product?) {
+// ------------------------
+// below are functions for demostrating conversions: revenue attribution events
+// ------------------------
+func fsAddOrRemoveProductEvent(event: Event, with product: Product?) {
     guard let product = product else {
         return
     }
-
+    // TODO: check for event type
     let productDict: [String : Any] = [
         "description_str": product.description,
         "displayName_str": product.title,
@@ -133,13 +136,18 @@ func fsCreateEvent(event: Event, with product: Product?) {
     fsCreateEvent(event: event, with: productDict)
 }
 
+func fsCheckoutSuccessEvent(event: Event, with order: Order) {
+    // TODO: check for event type
+    fsCreateEvent(event: event, with: order.orderSummary())
+}
+
 struct CheckoutError: Error {
     let errorCode: String
     let message: String
     let order: Order
 }
 
-func fsCreateEvent(event: Event, with error: CheckoutError) {
+func fsCheckoutErrorEvent(event: Event, with error: CheckoutError) {
     let errDict: [String : Any] = [
         "code_str": error.errorCode,
         "message_str": error.message,

--- a/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
+++ b/swift/ios-shoppe-demo/ServiceManagers/FullStoryManager.swift
@@ -118,12 +118,12 @@ func fsCreateEvent(event: Event, with product: Product?) {
     guard let product = product else {
         return
     }
-    
+
     let productDict: [String : Any] = [
         "description_str": product.description,
         "displayName_str": product.title,
         "id_str": product.title,
-        "imgName_str": product.image,
+        "imgName_str": product.imageName,
         "price_raw_real": product.price,
         "price_real": product.price,
         "product_id_str": makeId(len: 9),
@@ -147,6 +147,6 @@ func fsCreateEvent(event: Event, with error: CheckoutError) {
         "order.order_id": error.order.orderId,
         "order.total_real": error.order.cartOrderTotal
     ]
-    
+
     fsCreateEvent(event: event, with: errDict)
 }

--- a/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
+++ b/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
@@ -17,6 +17,9 @@ class CartQuantityTableViewCell: ProductViewCell {
         tableViewController?.setOrderItemsForCart()
         tableViewController?.tableView.reloadData()
 
+        //MARK: - Product removed event for conversion: revenue attribution
+        fsCreateEvent(event: .removeFromCart, with: product)
+        
         // MARK: - FullStory Logging Example
 
         fsLog(message: "\(product.title) was added from cart.", level: .info)
@@ -28,12 +31,15 @@ class CartQuantityTableViewCell: ProductViewCell {
             tableViewController?.tableView.reloadData()
             return
         }
-
+        
         product.quantity -= 1
 
         if product.quantity <= 0 {
             tableViewController?.setOrderItemsForCart()
         }
+        
+        //MARK: - Product removed event for conversion: revenue attribution
+        fsCreateEvent(event: .removeFromCart, with: product)
 
         tableViewController?.tableView.reloadData()
 

--- a/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
+++ b/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
@@ -18,7 +18,7 @@ class CartQuantityTableViewCell: ProductViewCell {
         tableViewController?.tableView.reloadData()
 
         //MARK: - Product removed event for conversion: revenue attribution
-        fsCreateEvent(event: .removeFromCart, with: product)
+        fsAddOrRemoveProductEvent(event: .removeFromCart, with: product)
         
         // MARK: - FullStory Logging Example
 
@@ -38,7 +38,7 @@ class CartQuantityTableViewCell: ProductViewCell {
         }
         
         // MARK: - Product removed event for conversion: revenue attribution
-        fsCreateEvent(event: .removeFromCart, with: product)
+        fsAddOrRemoveProductEvent(event: .removeFromCart, with: product)
 
         tableViewController?.tableView.reloadData()
 

--- a/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
+++ b/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
@@ -38,7 +38,7 @@ class CartQuantityTableViewCell: ProductViewCell {
             tableViewController?.setOrderItemsForCart()
         }
         
-        //MARK: - Product removed event for conversion: revenue attribution
+        // MARK: - Product removed event for conversion: revenue attribution
         fsCreateEvent(event: .removeFromCart, with: product)
 
         tableViewController?.tableView.reloadData()

--- a/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
+++ b/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
@@ -17,10 +17,10 @@ class CartQuantityTableViewCell: ProductViewCell {
         tableViewController?.setOrderItemsForCart()
         tableViewController?.tableView.reloadData()
 
-        //MARK: - Product removed event for conversion: revenue attribution
+        // MARK: Product removed event for conversion: revenue attribution
         fsAddOrRemoveProductEvent(event: .removeFromCart, with: product)
         
-        // MARK: - FullStory Logging Example
+        // MARK: FullStory Logging Example
 
         fsLog(message: "\(product.title) was added from cart.", level: .info)
     }
@@ -38,12 +38,12 @@ class CartQuantityTableViewCell: ProductViewCell {
             tableViewController?.setOrderItemsForCart()
         }
         
-        // MARK: - Product removed event for conversion: revenue attribution
+        // MARK: Product removed event for conversion: revenue attribution
         fsAddOrRemoveProductEvent(event: .removeFromCart, with: product)
 
         tableViewController?.tableView.reloadData()
 
-        // MARK: - FullStory Logging Example
+        // MARK: FullStory Logging Example
 
         fsLog(message: "\(product.title) was removed from cart.", level: .info)
     }

--- a/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
+++ b/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
@@ -31,7 +31,6 @@ class CartQuantityTableViewCell: ProductViewCell {
             tableViewController?.tableView.reloadData()
             return
         }
-        
         product.quantity -= 1
 
         if product.quantity <= 0 {

--- a/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
+++ b/swift/ios-shoppe-demo/Views/CartQuantityTableViewCell.swift
@@ -31,6 +31,7 @@ class CartQuantityTableViewCell: ProductViewCell {
             tableViewController?.tableView.reloadData()
             return
         }
+
         product.quantity -= 1
 
         if product.quantity <= 0 {

--- a/swift/ios-shoppe-demo/Views/CartTableViewController.swift
+++ b/swift/ios-shoppe-demo/Views/CartTableViewController.swift
@@ -32,7 +32,7 @@ class CartTableViewController: UITableViewController {
     }
 
     func setOrderItemsForCart() {
-        items = order.items.filter { $0.quantity > 0 }
+        items = order.getFilteredItems()
     }
 
     func presentCheckout() {

--- a/swift/ios-shoppe-demo/Views/CheckoutTableViewController.swift
+++ b/swift/ios-shoppe-demo/Views/CheckoutTableViewController.swift
@@ -46,7 +46,7 @@ class CheckoutTableViewController: UITableViewController {
             productView.modalPresentationStyle = .formSheet
             productView.checkoutTableViewController = self
 
-            // MARK: - FullStory Example Custom Event "Order Completed" for conversions: revenue attribution
+            // MARK: FullStory Example Custom Event "Order Completed" for conversions: revenue attribution
             fsCheckoutSuccessEvent(event: .checkout, with: order)
 
             present(productView, animated: true, completion: nil)
@@ -54,7 +54,7 @@ class CheckoutTableViewController: UITableViewController {
         else {
             let msg = "User tried to checkout without confirmation."
             let err: CheckoutError = CheckoutError(errorCode: "AC10XY2", message: msg, order: order)
-            // MARK: - FullStory Example logging
+            // MARK: FullStory Example logging
             fsLog(message: err.message, level: .error)
             fsCheckoutErrorEvent(event: .checkoutError, with: err)
         }

--- a/swift/ios-shoppe-demo/Views/CheckoutTableViewController.swift
+++ b/swift/ios-shoppe-demo/Views/CheckoutTableViewController.swift
@@ -46,14 +46,17 @@ class CheckoutTableViewController: UITableViewController {
             productView.modalPresentationStyle = .formSheet
             productView.checkoutTableViewController = self
 
-            // MARK: - FullStory Example CustomEvent
+            // MARK: - FullStory Example Custom Event "Order Completed" for conversions: revenue attribution
             fsCreateEvent(event: .checkout, with: order.orderSummary())
 
             present(productView, animated: true, completion: nil)
         }
         else {
+            let msg = "User tried to checkout without confirmation."
+            let err: CheckoutError = CheckoutError(errorCode: "AC10XY2", message: msg, order: order)
             // MARK: - FullStory Example logging
-            fsLog(message: "User tried to checkout without confirmation.", level: .error)
+            fsLog(message: err.message, level: .error)
+            fsCreateEvent(event: .checkoutError, with: err)
         }
     }
 

--- a/swift/ios-shoppe-demo/Views/CheckoutTableViewController.swift
+++ b/swift/ios-shoppe-demo/Views/CheckoutTableViewController.swift
@@ -47,7 +47,7 @@ class CheckoutTableViewController: UITableViewController {
             productView.checkoutTableViewController = self
 
             // MARK: - FullStory Example Custom Event "Order Completed" for conversions: revenue attribution
-            fsCreateEvent(event: .checkout, with: order.orderSummary())
+            fsCheckoutSuccessEvent(event: .checkout, with: order)
 
             present(productView, animated: true, completion: nil)
         }
@@ -56,7 +56,7 @@ class CheckoutTableViewController: UITableViewController {
             let err: CheckoutError = CheckoutError(errorCode: "AC10XY2", message: msg, order: order)
             // MARK: - FullStory Example logging
             fsLog(message: err.message, level: .error)
-            fsCreateEvent(event: .checkoutError, with: err)
+            fsCheckoutErrorEvent(event: .checkoutError, with: err)
         }
     }
 

--- a/swift/ios-shoppe-demo/Views/ProductSummaryView.swift
+++ b/swift/ios-shoppe-demo/Views/ProductSummaryView.swift
@@ -12,7 +12,7 @@ import UIKit
 class ProductSummaryView: UITableViewController {
     var checkoutTableViewController: CheckoutTableViewController!
     var purchasedItems: [Product] {
-        return order.items.filter { return $0.quantity > 0 }
+        return order.getFilteredItems()
     }
 
 
@@ -32,7 +32,7 @@ class ProductSummaryView: UITableViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        order.items.forEach { $0.quantity = 0 }
+        order.resetOrder()
         checkoutTableViewController.navigationController?.popToRootViewController(animated: true)
     }
 

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -101,7 +101,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
         generator.impactOccurred()
 
         order.addProduct(product)
-        //MARK: - Product removed event for conversion: revenue attribution
+        // MARK: - Product removed event for conversion: revenue attribution
         fsCreateEvent(event: .addToCart, with: order.getProduct(product))
         updateCartNumber()
     }

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -102,7 +102,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
 
         order.addProduct(product)
         // MARK: - Product removed event for conversion: revenue attribution
-        fsCreateEvent(event: .addToCart, with: order.getProduct(product))
+        fsAddOrRemoveProductEvent(event: .addToCart, with: order.getProduct(product))
         updateCartNumber()
     }
 

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -39,7 +39,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
 
         setupNavigationBar()
 
-        fsIdentify(id: user.id.uuidString, userInfo: user.infoDict)
+//        fsIdentify(id: user.id.uuidString, userInfo: user.infoDict)
 
         APIService.sharedInstance.getProductsFromFile { (productsRecieved) in
             if !productsRecieved.isEmpty {
@@ -101,6 +101,8 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
         generator.impactOccurred()
 
         order.addProduct(product)
+        //MARK: - Product removed event for conversion: revenue attribution
+        fsCreateEvent(event: .addToCart, with: order.getProduct(product))
         updateCartNumber()
     }
 

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -89,7 +89,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
     }
 
     func setCartUI() {
-        // MARK: - FullStory unmasking Example
+        // MARK: FullStory unmasking Example
         fsModifyPrivacy(setting: .unmask, views: cartNumberView.customView, barCartButton.customView)
 
         cartNumberView = UIBarButtonItem(title: "\(cartNumber)", style: .done, target: self, action: nil)
@@ -101,7 +101,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
         generator.impactOccurred()
 
         order.addProduct(product)
-        // MARK: - Product removed event for conversion: revenue attribution
+        // MARK: Product removed event for conversion: revenue attribution
         fsAddOrRemoveProductEvent(event: .addToCart, with: order.getProduct(product))
         updateCartNumber()
     }

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -39,7 +39,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
 
         setupNavigationBar()
 
-//        fsIdentify(id: user.id.uuidString, userInfo: user.infoDict)
+        fsIdentify(id: user.id.uuidString, userInfo: user.infoDict)
 
         APIService.sharedInstance.getProductsFromFile { (productsRecieved) in
             if !productsRecieved.isEmpty {
@@ -52,7 +52,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
                         else if let image = image {
                             item.image = image
                             DispatchQueue.main.async {
-                                order.items = self.products
+                                order.addItems(items: self.products)
                                 self.collectionView.reloadData()
                             }
                         }
@@ -83,7 +83,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
     }
 
     func updateCartNumber() {
-        let numberOfItems = order.items.reduce(0, { $0 + $1.quantity })
+        let numberOfItems = order.getNumberOfItems()
 
         cartNumber = numberOfItems
     }

--- a/swift/ios-shoppe-demo/Views/StoreViewController.swift
+++ b/swift/ios-shoppe-demo/Views/StoreViewController.swift
@@ -52,7 +52,7 @@ class StoreViewController: UICollectionViewController, UICollectionViewDelegateF
                         else if let image = image {
                             item.image = image
                             DispatchQueue.main.async {
-                                order.addItems(items: self.products)
+                                order.setItems(items: self.products)
                                 self.collectionView.reloadData()
                             }
                         }


### PR DESCRIPTION
Goal:
Support Conversions with Revenue attribution. This will be especially helpful once we get mobile frustration signals to bring demo-ability to conversions.

Need to Happen:
on Web there are 4 custom event that's useful for revenue op analysis:

**Order Completed**
```
order_id: guyywr4fu
revenue: 1513.74
shipping: 5.99
tax: 2.75
```

**Product Added**
```
description: Beans, beans... great for your heart.
displayName: Green Beans
hashKey: object:58 _(not in NM)_
id: beans
imgName: beans.jpg
price_raw: 1.79
price: 1.79
product_id: owu6yjpmq
unit: lb
Errors: [  _(not in NM)_
  {
    "Field": "$priority",
    "Value": "null",
    "ErrMsg": "invalidFieldName"
  }
]
```

**Product Removed**
```
description: Beans, beans... great for your heart.
displayName: Green Beans
hashKey: object:58 _(not in NM)_
id: beans
imgName: beans.jpg
price_raw: 1.79
price: 1.79
product_id: owu6yjpmq
unit: lb
Errors: [  _(not in NM)_
  {
    "Field": "$priority",
    "Value": "null",
    "ErrMsg": "invalidFieldName"
  }
]
```

**Checkout Error**
```
code: AC10XY2
message: invalid. Uh. Something went wrong.
order.items: 2
order.order_id: rj9hsk3ad
order.total: 5.78
type: Server Error (500) _(Not in NM)_
```

Each event has it's own properties, to support that, we need a new table that holds the order id (we don't have a backend for fruiteshoppe mobile, so this is locally generated for now)

Changes:
In Order model it holds a order Id along with shipping and tax info
**Overloaded `fsCreateEvent` to take Error or Product** - This is where I'm hazy on what the best way to fit the use cases into the `fsManager` class @HaroldFS for help :)

At different controllers where Product Added and Product Removed are appropriate, or checkout events, call the correct `fsCreateEvent`

Future:
This doesn't cover 100% of what web is doing but at least brings us close to being able to get some conversions signal
We should emit order validation error instead of throwing a generic error
We should share a backend with web so we can persist cart/order info cross platform